### PR TITLE
fix(example): migrate deprecated Material buttons to modern widgets

### DIFF
--- a/example/lib/date_pick.dart
+++ b/example/lib/date_pick.dart
@@ -15,17 +15,17 @@ class _PickerState extends State<PickerPage> {
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: <Widget>[
-            RaisedButton(
+            ElevatedButton(
                 onPressed: () {
                   _showPicker(context, DateTimePickerMode.date);
                 },
                 child: Text("日期选择")),
-            RaisedButton(
+            ElevatedButton(
                 onPressed: () {
                   _showPicker(context, DateTimePickerMode.datetime);
                 },
                 child: Text("日期+时间选择")),
-            RaisedButton(
+            ElevatedButton(
                 onPressed: () {
                   _showPicker(context, DateTimePickerMode.time);
                 },

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -29,7 +29,7 @@ class _AppState extends State<AppPage> {
       appBar: AppBar(title: Text("Time Picker")),
       body: Container(
         child: Center(
-          child: RaisedButton(
+          child: ElevatedButton(
               onPressed: () {
                 Navigator.of(context).pushNamed("/picker");
               },


### PR DESCRIPTION
Migrates deprecated Material buttons in example code to current widgets:

- RaisedButton -> ElevatedButton
- FlatButton -> TextButton
- OutlineButton -> OutlinedButton

This removes analyzer deprecation warnings and aligns examples with Flutter stable.
No library code changed; examples only.